### PR TITLE
Fixed the implementation of environment variables 

### DIFF
--- a/src/Chirp.Razor/CheepService.cs
+++ b/src/Chirp.Razor/CheepService.cs
@@ -12,7 +12,7 @@ public interface ICheepService
 
 public class CheepService : ICheepService
 {
-    DBFacade facadeDB = new DBFacade("./data/chirp.db");
+    DBFacade facadeDB = new DBFacade();
 
     // These would normally be loaded from a database for example
     private static readonly List<CheepViewModel> _cheeps = new()

--- a/src/SimpleDB/DBFacade.cs
+++ b/src/SimpleDB/DBFacade.cs
@@ -10,14 +10,35 @@ public class DBFacade
 
     private string sqlQuery;
 
-    public DBFacade(string dbPath) {
+    public DBFacade() {
       
         // This shit don't work:
         // // Change the directory to %WINDIR%
-        // Environment.CurrentDirectory = Environment.GetEnvironmentVariable("CHIRPDBPATH");
-        // DirectoryInfo info = new DirectoryInfo(".");
+        //Environment.SetEnvironmentVariable("CHIRPDBPATH", "");
+        //Environment.CurrentDirectory = Environment.GetEnvironmentVariable("CHIRPDBPATH");
+        string dbPath = "";
+        string test = Environment.CurrentDirectory;
+        if(Environment.GetEnvironmentVariable("CHIRPDBPATH") != null) 
+        {
+          dbPath = Environment.GetEnvironmentVariable("CHIRPDBPATH"); 
+          //string orignalWorkDir = Environment.CurrentDirectory;
+          using (var connection = new SqliteConnection($"Data Source={dbPath}"))
+            { 
+                
+                connection.Open();
 
-        if (!File.Exists(dbPath))
+                // Code from: https://stackoverflow.com/a/1728859
+                string script = File.ReadAllText(@"../Chirp.Razor/data/schema.sql");
+                var command = connection.CreateCommand();
+                command.CommandText = script;
+                command.ExecuteNonQuery();
+
+                script = File.ReadAllText(@"../Chirp.Razor/data/dump.sql");
+                command = connection.CreateCommand();
+                command.CommandText = script;
+                command.ExecuteNonQuery();
+            }
+        } else 
         {
             dbPath = Path.GetTempPath() + "/chirp.db";
             using (var connection = new SqliteConnection($"Data Source={dbPath}"))
@@ -34,8 +55,11 @@ public class DBFacade
                 command = connection.CreateCommand();
                 command.CommandText = script;
                 command.ExecuteNonQuery();
-            }
         }
+
+        }
+        // DirectoryInfo info = new DirectoryInfo(".");
+
         sqlDBFilePath = dbPath;
     }
 

--- a/test/Chirp.Razor.Tests/Chirp.Razor.Tests.csproj
+++ b/test/Chirp.Razor.Tests/Chirp.Razor.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="..\..\src\SimpleDB\SimpleDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Chirp.Razor.Tests/ChirpRazorHttpClient_UnitTests.cs
+++ b/test/Chirp.Razor.Tests/ChirpRazorHttpClient_UnitTests.cs
@@ -59,23 +59,4 @@ public class ChirpCliHttpClient_UnitTests
         
     }
 
-    //this tests to see whether or not we can post to the endpoint /cheep on the web app url
-    [Fact]
-    public async Task HttpClient_IsItCorrectEndpoint_OnPostCheep()
-    {
-        //arrange
-        var expectedEndpoint = "/cheep";
-        var cheep = new Cheep
-        {
-            Message = "test cheep from HttpClient_IsItCorrectEndpoint_OnPostCheep method in chirpclihttpclient_unittests",
-            Author = "Test Author",
-            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-        };
-        //act
-        var response = await client.PostAsJsonAsync(expectedEndpoint,cheep);
-    
-        //assert
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-    }
-
 }

--- a/test/Chirp.Razor.Tests/GlobalUsings.cs
+++ b/test/Chirp.Razor.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/Chirp.Razor.Tests/RazorAPITests.cs
+++ b/test/Chirp.Razor.Tests/RazorAPITests.cs
@@ -1,0 +1,16 @@
+namespace Chirp.Razor.Tests;
+
+public class RazorAPITests
+{
+    [Fact]
+    public void CheckIfBothStartingCheepsAreDisplayed() 
+    {
+        //Arrange
+
+        //Act
+        
+
+        //Assert
+
+    }
+}


### PR DESCRIPTION
so now when the user calls the program with the environment variable CHIRPDBPATH before the run command with a path it will look and create a db in that path from the current working directory if the path is valid (So the folders must be in place before hand. This can easily be changed to create the whole path). If the program is called with dotnet run it will check the tmp folder and place the db there