### PR TITLE
Ordered cheeps in public and private timeline.

### DIFF
--- a/src/SimpleDB/ChirpRepository/AuthorRepository.cs
+++ b/src/SimpleDB/ChirpRepository/AuthorRepository.cs
@@ -42,6 +42,7 @@ public class AuthorRepository : IDatabaseRepository<Author>
         }
 
         // query format from StackOverflow: https://stackoverflow.com/a/29205357
+        // from from stm from StackOverflow: https://stackoverflow.com/a/6257269
         // orderby descending inspired from StackOverflow: https://stackoverflow.com/a/9687214
         var query = (from author_ in DbSet
                     where author_ == authorEntity

--- a/src/SimpleDB/ChirpRepository/AuthorRepository.cs
+++ b/src/SimpleDB/ChirpRepository/AuthorRepository.cs
@@ -38,16 +38,21 @@ public class AuthorRepository : IDatabaseRepository<Author>
 
         if (authorEntity == null)
         {
-            return (new List<Cheep>(), 0);
+            return (null, 0);
         }
 
-        // from StackOverflow: https://stackoverflow.com/a/29205357
-        var page = DbSet.Skip(offset).Take(limit);
-        var query = (from author_ in page
+        // query format from StackOverflow: https://stackoverflow.com/a/29205357
+        // orderby descending inspired from StackOverflow: https://stackoverflow.com/a/9687214
+        var query = (from author_ in DbSet
                     where author_ == authorEntity
-                    select author_.Cheeps).FirstOrDefault();
+                    from cheep in author_.Cheeps
+                    orderby cheep.TimeStamp descending
+                    select cheep)
+                    .Skip(offset)
+                    .Take(limit)
+                    .ToList();
 
-        return (query, DbSet.Count());
+        return (query, authorEntity.Cheeps.Count);
     }
 
     public Author? GetById(int id)

--- a/src/SimpleDB/ChirpRepository/CheepRepository.cs
+++ b/src/SimpleDB/ChirpRepository/CheepRepository.cs
@@ -43,16 +43,19 @@ public class CheepRepository : IDatabaseRepository<Cheep>
     public (List<Cheep>, int) GetSome(int offset, int limit)
     {
         // From StackOverflow: https://stackoverflow.com/a/29205357
-        var page = DbSet.Skip(offset).Take(limit);
-        var query = (from cheep in page
+        var query = (from cheep in DbSet
+                    .OrderByDescending(d => d.TimeStamp)
+                    .Skip(offset)
+                    .Take(limit)
                     select new Cheep
                     {
                         CheepId = cheep.CheepId,
                         Author = cheep.Author,
                         Text = cheep.Text,
                         TimeStamp = cheep.TimeStamp
-                    }).ToList();
-        
+                    })
+                    .ToList();
+
         return (query, DbSet.Count());
     }
 

--- a/src/SimpleDB/ChirpRepository/CheepRepository.cs
+++ b/src/SimpleDB/ChirpRepository/CheepRepository.cs
@@ -43,6 +43,7 @@ public class CheepRepository : IDatabaseRepository<Cheep>
     public (List<Cheep>, int) GetSome(int offset, int limit)
     {
         // From StackOverflow: https://stackoverflow.com/a/29205357
+        // Order by desc (x => x.Field) from StackOverflow: https://stackoverflow.com/a/5813479
         var query = (from cheep in DbSet
                     .OrderByDescending(d => d.TimeStamp)
                     .Skip(offset)

--- a/test/Chirp.Razor.Tests/IntegrationTests.cs
+++ b/test/Chirp.Razor.Tests/IntegrationTests.cs
@@ -71,7 +71,7 @@ public class IntegrationTest : IClassFixture<WebApplicationFactory<Program>>
         var contentPage = await response.Content.ReadAsStringAsync();
 
         string firstCheepAuthor = "<a href=\"/Jacqualine Gilcoine\">Jacqualine Gilcoine</a>";
-        string firstCheepMessage = "hey were married in Chicago, with old Smith, and was expected aboard every day; meantime, the two went past me.";
+        string firstCheepMessage = "Starbuck now is what we hear the worst.";
 
         Assert.Contains("<h2> Public Timeline </h2>", contentPage);
         Assert.Contains(firstCheepAuthor, contentPage);


### PR DESCRIPTION
Might want to refactor the integration-test w/ first cheep again...

On public timeline and Jacqualine G's private timeline, the first cheep is now again:
```[Jacqualine Gilcoine] Starbuck now is what we hear the worst. — 08/01/2023 13:17:39```

The public timeline's last cheep is:
```[Helge] Hello, BDSA students! — 08/01/2023 12:16:48```
